### PR TITLE
fix same word phrase and multi space bug

### DIFF
--- a/src/main/java/org/apache/lucene/analysis/vi/VietnameseTokenizer.java
+++ b/src/main/java/org/apache/lucene/analysis/vi/VietnameseTokenizer.java
@@ -79,25 +79,21 @@ public class VietnameseTokenizer extends Tokenizer {
                 typeAtt.setType(String.format("<%s>", word.getRule().getName().toUpperCase()));
                 termAtt.copyBuffer(word.getText().toCharArray(), 0, length);
                 final int start = inputText.indexOf(word.getText(), offset);
-                int startChange = start;
+                int startChange = -1;
                 int lengthChange = length;
 
-                if (start < 0) {
+                // fix same word phrase and multi space bug
+                if(word.getText().indexOf(" ") < 0) {
+                    startChange = inputText.indexOf(word.getText(), offset);
+                } else {
                     // fix multi space bug
                     // #67, #68
-                    if (word.getText() != null) {
-                        String[] originArray = word.getText().split(" ");
-                        String firstWord = originArray[0];
-                        String lastWord = originArray[originArray.length - 1];
-                        startChange = inputText.indexOf(firstWord, offset);
-                        if (originArray.length == 1) {
-                            lengthChange = inputText.indexOf(lastWord, offset) - startChange
-                                    + lastWord.length();
-                        } else {
-                            lengthChange = inputText.indexOf(lastWord, startChange + firstWord.length()) - startChange
-                                    + lastWord.length();
-                        }
-                    }
+                    String[] originArray = word.getText().split(" ");
+                    String firstWord = originArray[0];
+                    String lastWord = originArray[originArray.length - 1];
+                    startChange = inputText.indexOf(firstWord, offset);
+                    lengthChange = inputText.indexOf(lastWord, startChange + firstWord.length()) - startChange
+                            + lastWord.length();
                 }
                 offsetAtt.setOffset(
                         correctOffset(startChange),

--- a/src/test/java/org/elasticsearch/index/analysis/VietnameseAnalysisTokenTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/VietnameseAnalysisTokenTest.java
@@ -28,6 +28,11 @@ public class VietnameseAnalysisTokenTest extends ESTestCase {
         inputToken("#Mama & #I. 😘\n\n#HoChiMinh, #Vietnam.", new String[] {"mama", "i", "😘", "hochiminh", "vietnam"});
     }
 
+    public void testVietnameseTokenizerSameWordPhraseAndMultiSpace() throws IOException {
+        inputToken("Giảm 20k cho đơn  từ 299K. Giảm 30k cho đơn từ 399K",
+                new String[] {"giảm", "20", "k", "đơn từ", "299", "k", "giảm", "30", "k", "đơn từ", "399", "k"});
+    }
+
     private void inputToken(String inputText, String[] expectArray) throws IOException {
         TestAnalysis analysis = VietnameseAnalysisTest.createTestAnalysis();
         NamedAnalyzer analyzer = analysis.indexAnalyzers.get("vi_analyzer");


### PR DESCRIPTION
An issue when analyze string :
```
Giảm 20k cho đơn  từ 299K. Giảm 30k cho đơn từ 399K
```
(first "đơn  từ" have two space characters)
===> "startOffset must be non-negative, and endOffset must be >= startOffset; got startOffset=-1,endOffset=2"
In this paragraph tokenizer result include word phrase "đơn từ"
This word phrase don't match first "đơn từ" (because two space in between), it's match the second "đơn từ" phrase in paragraph.
I fixed it.
And i removed the check null word (if it is null, exception thrown before)
```java
if (word.getText() != null) {
...
}
```

