### PR TITLE
cập nhật tương thích 7.16, 7.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Edit the `elasticsearch-analysis-vietnamese/pom.xml` to change the version of El
 ...
 <groupId>org.elasticsearch</groupId>
 <artifactId>elasticsearch-analysis-vietnamese</artifactId>
-<version>7.4.0</version>
+<version>7.17.1</version>
 ...
  ```
 
@@ -114,8 +114,9 @@ If you want to use the plugin with prior versions of Elasticsearch, you can buil
 
 | Vietnamese Analysis Plugin | Elasticsearch |
 | -------------------------- | ------------- |
-| master                     | 7.12.1        |
-| 7.12.1                     | 7.12.1        |     
+| chưa hỗ trợ                | 8.x           |
+| master                     | 7.16~7.17     |
+| 7.12.1                     | 7.12.1~7.15.x |     
 | 7.3.1                      | 7.3.1         |   
 | 5.6.5                      | 5.6.5         |
 | 5.4.1                      | 5.4.1         |

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-vietnamese</artifactId>
-    <version>7.4.0</version>
+    <version>7.17.1</version>
     <packaging>jar</packaging>
     <name>elasticsearch-analysis-vietnamese</name>
     <url>https://github.com/duydo/elasticsearch-analysis-vietnamese/</url>

--- a/src/test/java/org/elasticsearch/index/analysis/VietnameseAnalysisIntegrationTests.java
+++ b/src/test/java/org/elasticsearch/index/analysis/VietnameseAnalysisIntegrationTests.java
@@ -5,7 +5,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.plugin.analysis.vi.AnalysisVietnamesePlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 


### PR DESCRIPTION
mình sửa build theo thông tin tại https://www.elastic.co/guide/en/elastic-stack/7.16/elasticsearch-breaking-changes.html#breaking_716_hlrc_changes

các bản cũ hơn thường bị cảnh báo về log4shell trong image.