### PR TITLE
align docker build and maven build output version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ RUN wget https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.
 ENV MVN_HOME=/tmp/apache-maven-3.8.8
 ENV PATH=$MVN_HOME/bin:$PATH
 
+ARG ES_VERSION
 COPY . /tmp/elasticsearch-analysis-vietnamese
 WORKDIR /tmp/elasticsearch-analysis-vietnamese
 RUN mvn verify clean --fail-never
-RUN mvn --batch-mode -Dmaven.test.skip -e package
+RUN mvn --batch-mode -Dmaven.test.skip -e package -DprojectVersion=$ES_VERSION
 
 FROM docker.elastic.co/elasticsearch/elasticsearch:$ES_VERSION
 ARG ES_VERSION

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-vietnamese</artifactId>
-    <version>8.7.0</version>
+    <version>${projectVersion}</version>
     <packaging>jar</packaging>
     <name>elasticsearch-analysis-vietnamese</name>
     <url>https://github.com/duydo/elasticsearch-analysis-vietnamese/</url>
@@ -31,6 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.java.version>1.8</project.build.java.version>
+        <projectVersion>8.7.0</projectVersion>
         <elasticsearch.version>${project.version}</elasticsearch.version>
         <log4j.version>2.17.2</log4j.version>
     </properties>


### PR DESCRIPTION
maven uses the hardcoded version `8.7.0` and outputs zip file with `8.7.0` in file name suffix. This breaks COPY command